### PR TITLE
Default genre_ids_str to empty string

### DIFF
--- a/TMDB.py
+++ b/TMDB.py
@@ -170,7 +170,8 @@ class TMDB():
     
     def get_genre_id_list(self):
         
-        genre_ids = []        
+        genre_ids = []
+        genre_ids_str = ""
         
         for genre in options.exclude_genres:
             genre_ids.append(str(genre.value))


### PR DESCRIPTION
This addresses an error raised when the movie genre exclusions array is empty